### PR TITLE
Fix Anime and Manga Search

### DIFF
--- a/my_anime_list/anime.rb
+++ b/my_anime_list/anime.rb
@@ -502,7 +502,7 @@ module MyAnimeList
             anime_title_node = results_row.at('td a strong')
             next unless anime_title_node
             url = anime_title_node.parent['href']
-            next unless url.match %r{http://myanimelist.net/anime/(\d+)/?.*}
+            next unless url.match %r{/anime/(\d+)/?.*}
 
             anime = Anime.new
             anime.id = $1.to_i

--- a/my_anime_list/manga.rb
+++ b/my_anime_list/manga.rb
@@ -168,7 +168,7 @@ module MyAnimeList
           manga_title_node = results_row.at('td a strong')
           next unless manga_title_node
           url = manga_title_node.parent['href']
-          next unless url.match %r{http://myanimelist.net/manga/(\d+)/?.*}
+          next unless url.match %r{/manga/(\d+)/?.*}
 
           manga = Manga.new
           manga.id = $1.to_i


### PR DESCRIPTION
MAL changed URLs in the search results to be relative. Update the logic
to look for the new relative URLs instead of the old absolute ones.
