### PR TITLE
Fix Year as a Date on Either Side for Anime

### DIFF
--- a/my_anime_list/anime.rb
+++ b/my_anime_list/anime.rb
@@ -864,7 +864,11 @@ module MyAnimeList
           date_string = text.split(/\s+to\s+/).first
           return nil if !date_string
 
-          Chronic.parse(date_string)
+          if date_string =~ /^\d{4}$/
+            return date_string.strip
+          else
+            Chronic.parse(date_string)
+          end
         end
       end
 
@@ -882,7 +886,11 @@ module MyAnimeList
           date_string = text.split(/\s+to\s+/).last
           return nil if !date_string
 
-          Chronic.parse(date_string)
+          if date_string =~ /^\d{4}$/
+            return date_string.strip
+          else
+            Chronic.parse(date_string)
+          end
         end
       end
 


### PR DESCRIPTION
The anime date parser was broken in certain edge cases where the end date
was a plain year. Chronic can't parse it properly as it's ambiguous.
Instead, it was just returning the current date. Now, we do a check for
a bare year after splitting on both the start and end dates to avoid this
problem.

This can easily be tested for the end date on anime id 11835.
